### PR TITLE
Fix to use named arguments with resample

### DIFF
--- a/noisyspeech_synthesizer_singleprocess.py
+++ b/noisyspeech_synthesizer_singleprocess.py
@@ -68,7 +68,7 @@ def build_audio(is_clean, params, index, audio_samples_length=-1):
         idx = (idx + 1) % np.size(source_files)
         input_audio, fs_input = audioread(source_files[idx])
         if fs_input != fs_output:
-            input_audio = librosa.resample(input_audio, fs_input, fs_output)
+            input_audio = librosa.resample(input_audio, orig_sr=fs_input, target_sr=fs_output)
 
         # if current file is longer than remaining desired length, and this is
         # noise generation or this is training set, subsample it randomly


### PR DESCRIPTION
This fixes call to `resample` function to use named arguments due to breaking change in `librosa`.

See https://github.com/librosa/librosa/pull/1521